### PR TITLE
a few initial suggestions

### DIFF
--- a/Methanogen.Rproj
+++ b/Methanogen.Rproj
@@ -18,3 +18,4 @@ StripTrailingWhitespace: Yes
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd,collate,namespace

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(calculate.KH)
 export(calculate.Kgas)
 export(methanogenesis)
+export(qty)
 import(CHNOSZ)
 import(dplyr)
 import(mathjaxr)

--- a/R/import_packages.R
+++ b/R/import_packages.R
@@ -1,5 +1,11 @@
+#
 #' @import CHNOSZ
 #' @import microbialkitchen
 #' @import mathjaxr
 #' @import dplyr
 NULL
+
+
+# re-export qty from microbialkitchen so folks can use it without needing to load microbialkitchen explicitly
+#' @export
+microbialkitchen::qty

--- a/R/methanogenesis.R
+++ b/R/methanogenesis.R
@@ -86,6 +86,7 @@ init <- function(CH4.initial, K.CH4, H2.initial, K.H2,
 #' @param delta.DIC step size, in millimolar. 0.1 mM by default.
 #' @param biomass.yield mass of dry biomass produced per mol of product. 2.4 g/mol product by default.
 #' @param carbon.fraction w/w percent C of biomass, expressed as a decimal. 0.44 by default.
+#' @param cell.weight a weight quantity, example: \code{cell_weight = qty(20, "fg")}
 #' @return A data frame of the model results
 #' @examples
 #' methanogenesis(CH4.initial = 1e-6,H2.initial = 5e-4,DIC.initial = 3.2e-3,pH.initial = 7.5,standard.gibbs = -191359.46584,temperature = 273.15+40,VolumeSolution = 80e-3,VolumeHeadspace = 20e-3,delta.DIC = 0.0001)
@@ -94,7 +95,13 @@ init <- function(CH4.initial, K.CH4, H2.initial, K.H2,
 methanogenesis <- function(CH4.initial, K.CH4=NA, H2.initial, K.H2=NA,
                            DIC.initial, pH.initial, K.CO2=NA, standard.gibbs=-191359.46584, temperature,
                            VolumeSolution, VolumeHeadspace, K.CO2HCO3 = NA, K.HCO3CO3 = NA,
-                           delta.DIC=0.0001, inoculum.cell.number = 1,biomass.yield=2.4,carbon.fraction=0.44,cell.weight=30e-15){
+                           delta.DIC=0.0001, inoculum.cell.number = 1,biomass.yield=2.4,carbon.fraction=0.44,cell.weight=qty(30, "fg")){
+
+  # safety checks for qty parameters
+  if(!microbialkitchen::is_mass(cell.weight)) stop("cell.weight must be a mass qty() like qty(30, 'fg')", call. = FALSE)
+
+  # convert quantities to specific units for downstream calculations
+  cell.weight <- microbialkitchen::get_qty_value(cell.weight, "g")
 
   #Calculates Henry's constants if they aren't already provided
   if (is.na(K.CH4)){

--- a/R/methanogenesis.R
+++ b/R/methanogenesis.R
@@ -1,7 +1,7 @@
 #' Determines initial conditions from initial inputs
 #'
 #' `init()` sets up the initial environment to be used by the methanogenesis model.
-#' @param CH4.initial Concentration of initial dissolved CH4, in molarity.
+#' @inheritParams methanogenesis
 #' @param K.CH4 Henry's constant for CH4.
 #' @param H2.initial Concentration of initial dissolved H2, in molarity.
 #' @param K.H2 Henry's constant for H2.


### PR DESCRIPTION
hi @altahowells4 and @mankeldy - great presentation from Alta today and a few quick suggestions in reponse

see code changes for using `qty` to make parameters with units safer for the user to specify and then work with inside functions

also, R does not allow `_` or ` ` in published packages so if you want to call it `Methanogen Lab` you have to do `MethanogenLab` or `methanogenlab` (case-sensitive)

i'm having trouble running the `methanogenesis` function example but that might be because of some of the dependencies. 

You can circumvent some issues with function names by avoiding `#' @import CHNOSZ` (which imports ALL functions) and instead just import what you want to use, e.g. `#' @importFrom CHNOSZ func1 func2 func3` or skipping the namespace import entirely and instead referring to imported functions with explicit namspaces, e.g. `microbialkitchen::is_mass(...)`. I prefer the latter because it makes it clear what functions are used from other packages (in case something breaks in another package) for all instances except when using other package functions in parameter defaults because the namespace version gets too lenthy. So for example in the case of `some_function <- function(T = qty(25, "C"))` I think it's better to include `"' @importFrom microbialkitchen qty` instead of the lengthier `some_function <- function(T = microbialkitchen::qty(25, "C"))`

anyways, great work! if you want I can take a few minutes some time and propose how to make the GUI as a shinyApp instead of python so it runs more easily without other language dependencies (runs in browser for platform independence)